### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 : "${SCHEDULE_HOUR:=0}"
 : "${SCHEDULE_DAY:=0}"
 
-echo "$SCHEDULE_MIN $SCHEDULE_HOUR * * $SCHEDULE_DAY python3 /app/clean_email.py >> /proc/1/fd/1 2>&1" > /tmp/cronjob
+echo "$SCHEDULE_MIN $SCHEDULE_HOUR * * $SCHEDULE_DAY /usr/local/bin/python3 /app/clean_email.py >> /proc/1/fd/1 2>&1" > /tmp/cronjob
 crontab /tmp/cronjob
-python3 /app/clean_email.py
+/usr/local/bin/python3 /app/clean_email.py
 cron -f


### PR DESCRIPTION
Fix https://github.com/gioxx/clean-mail-automation/issues/8 (entrypoint now uses the explicit interpreter path /usr/local/bin/python3 for both the cron job and the initial run)