### PR TITLE
fix: cron env inheritance, mobile UI, and empty last-run state

### DIFF
--- a/clean_email.py
+++ b/clean_email.py
@@ -440,6 +440,15 @@ if __name__ == "__main__":
     for index, mailbox_config in enumerate(mailbox_configs, start=1):
         logging.info("Processing mailbox %s/%s.", index, len(mailbox_configs))
         if not validate_mailbox_config(mailbox_config):
+            results.append({
+                "mailbox_address": mailbox_config.get("email_address") or mailbox_config.get("email_user") or "unknown",
+                "mailbox_name": mailbox_config.get("mailbox", DEFAULT_MAILBOX),
+                "status": "error",
+                "deleted_count": 0,
+                "days": mailbox_config.get("clean_days", 0),
+                "duration_seconds": 0,
+                "error_message": "Missing required configuration (imap_server, email_user or email_pass).",
+            })
             continue
         result = delete_old_emails(mailbox_config)
         notify_cleanup_result(result)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,11 +28,18 @@ DIGEST_SCHEDULE_MIN=$(sanitize_cron_field "$DIGEST_SCHEDULE_MIN" "0")
 DIGEST_SCHEDULE_HOUR=$(sanitize_cron_field "$DIGEST_SCHEDULE_HOUR" "8")
 DIGEST_SCHEDULE_DAY=$(sanitize_cron_field "$DIGEST_SCHEDULE_DAY" "0")
 
-echo "$SCHEDULE_MIN $SCHEDULE_HOUR * * $SCHEDULE_DAY /usr/local/bin/python3 /app/clean_email.py >> /proc/1/fd/1 2>&1" > /tmp/cronjob
+# Dump container environment for cron jobs (cron does not inherit Docker env vars).
+/usr/local/bin/python3 -c "
+import os, shlex
+for k, v in os.environ.items():
+    print(f'export {k}={shlex.quote(v)}')
+" > /tmp/container_env.sh
+
+echo "$SCHEDULE_MIN $SCHEDULE_HOUR * * $SCHEDULE_DAY /bin/bash -c 'source /tmp/container_env.sh && /usr/local/bin/python3 /app/clean_email.py' >> /proc/1/fd/1 2>&1" > /tmp/cronjob
 
 # Add digest sender cron only when digest mode is active.
 if [ "${TELEGRAM_NOTIFY_MODE:-always}" = "digest" ]; then
-    echo "$DIGEST_SCHEDULE_MIN $DIGEST_SCHEDULE_HOUR * * $DIGEST_SCHEDULE_DAY /usr/local/bin/python3 /app/clean_email.py --send-digest >> /proc/1/fd/1 2>&1" >> /tmp/cronjob
+    echo "$DIGEST_SCHEDULE_MIN $DIGEST_SCHEDULE_HOUR * * $DIGEST_SCHEDULE_DAY /bin/bash -c 'source /tmp/container_env.sh && /usr/local/bin/python3 /app/clean_email.py --send-digest' >> /proc/1/fd/1 2>&1" >> /tmp/cronjob
 fi
 
 crontab /tmp/cronjob

--- a/status_server.py
+++ b/status_server.py
@@ -189,6 +189,18 @@ main { max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem; display: grid; g
 .grid-2 { display: grid; grid-template-columns: 35fr 65fr; gap: 1.25rem; }
 @media (max-width: 660px) { .grid-2 { grid-template-columns: 1fr; } }
 
+/* ---- Mobile ---- */
+@media (max-width: 540px) {
+    header { padding: 0.75rem 1rem; }
+    .meta { text-align: left; }
+    main { padding: 1rem 0.75rem; }
+    .mini-grid { grid-template-columns: 1fr; }
+    .mini-box { grid-column: 1 / -1 !important; }
+    table { min-width: unset; font-size: 0.78rem; }
+    thead th, tbody td { padding: 0.45rem 0.5rem; }
+    .guide-body table { min-width: 420px; }
+}
+
 /* ---- Stat rows ---- */
 .stat-row { display: flex; flex-direction: column; gap: 0.2rem; margin-bottom: 0.9rem; }
 .stat-row:last-child { margin-bottom: 0; }
@@ -515,10 +527,8 @@ def _render_html():
                 f"<td class='{'cell-err' if error else 'cell-muted'}'>{escape(error) if error else '—'}</td>"
                 f"</tr>"
             )
-        last_run_html = f"""
-        <section class="card">
-            <p class="card-title">Last Run &nbsp;·&nbsp; {ts}</p>
-            <div class="table-wrap">
+        run_body = (
+            f"""<div class="table-wrap">
                 <table>
                     <thead>
                         <tr>
@@ -528,7 +538,14 @@ def _render_html():
                     </thead>
                     <tbody>{run_rows}</tbody>
                 </table>
-            </div>
+            </div>"""
+            if run_rows else
+            "<p class='empty'>Run recorded but no mailbox results found — check container logs for details.</p>"
+        )
+        last_run_html = f"""
+        <section class="card">
+            <p class="card-title">Last Run &nbsp;·&nbsp; {ts}</p>
+            {run_body}
         </section>"""
     else:
         last_run_html = """

--- a/status_server.py
+++ b/status_server.py
@@ -17,7 +17,7 @@ from html import escape
 
 STATE_FILE = "/tmp/clean_mail_last_run.json"
 DEFAULT_MAILBOX = "INBOX"
-APP_VERSION = "0.5"
+APP_VERSION = "0.5.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What's changed

**Fix: cron scheduled runs lose environment variables**
Docker's `cron` daemon does not inherit the container's environment. This caused
scheduled runs to start without `MAILBOX_CONFIGS`, `TELEGRAM_BOT_TOKEN`, and all
other env vars, while the immediate run at container start worked fine.
The entrypoint now dumps the full environment to `/tmp/container_env.sh` (values
are properly quoted via Python's `shlex.quote` to handle JSON and special chars),
and each cron command sources it before calling the script.

**Fix: mailboxes failing validation now appear in Last Run**
When a mailbox was skipped due to missing required fields, it was silently dropped
from `results`, leaving the Last Run table empty. It now records an `error` entry
so the status page makes the problem visible without digging into container logs.

**Fix: Last Run table shows a message when results list is empty**
Edge case for state files written by older versions: instead of an empty table,
a descriptive message is shown.

**Improvement: responsive layout on mobile**
Added a `@media (max-width: 540px)` breakpoint that stacks the notification
mini-grid to a single column, reduces header and main padding, and shrinks table
cell padding so the page is usable on narrow screens.