### PR TITLE
Sticky header + bump 0.5.3

### DIFF
--- a/status_server.py
+++ b/status_server.py
@@ -17,7 +17,7 @@ from html import escape
 
 STATE_FILE = "/tmp/clean_mail_last_run.json"
 DEFAULT_MAILBOX = "INBOX"
-APP_VERSION = "0.5.2"
+APP_VERSION = "0.5.3"
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +161,9 @@ header {
     justify-content: space-between;
     gap: 1rem;
     flex-wrap: wrap;
+    position: sticky;
+    top: 0;
+    z-index: 10;
 }
 .logo { display: flex; align-items: center; gap: 0.6rem; }
 .logo svg { color: var(--accent); flex-shrink: 0; }


### PR DESCRIPTION
## Summary
- Make top header sticky on the status page (consistent with spam-digest)
- Bump version to 0.5.3

## Test plan
- [x] Scroll the status page and verify the header stays pinned
- [x] Check mobile viewport